### PR TITLE
Fix : 'Can't Assign Requested Address' Error When Localhost Address i…

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -184,9 +184,9 @@ impl UdpStream {
     #[allow(unused)]
     pub async fn connect(addr: SocketAddr) -> Result<Self, tokio::io::Error> {
         let local_addr: SocketAddr = if addr.is_ipv4() {
-            SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 0)
+            SocketAddr::new(IpAddr::V4(Ipv4Addr::UNSPECIFIED), 0)
         } else {
-            SocketAddr::new(IpAddr::V6(Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 1)), 0)
+            SocketAddr::new(IpAddr::V6(Ipv6Addr::UNSPECIFIED), 0)
         };
 
         let socket = Arc::new(UdpSocket::bind(local_addr).await?);


### PR DESCRIPTION
A UDP socket can't bind to an unavailable address on machines, so the use of 127.0.0.1 can result in an error if the localhost interface is not available or use a custom/different IP address.

Solution: changing 127.0.0.1 address to 0.0.0.0, which is always available.

Fix https://github.com/SajjadPourali/udp-stream/issues/2